### PR TITLE
added original repo link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Very minimal greeter theme for lightdm webkit2.
 
 _Heavily_ ~~plagerised from~~ inspired by `lightdm-webkit2-theme-arch` ([aur](https://aur.archlinux.org/packages/lightdm-webkit2-theme-arch/) / [gitlab](https://gitlab.com/kenogo/lightdm-webkit2-theme-arch) / [github](https://github.com/kenogo/lightdm-webkit2-theme-arch)), which used wallpapers from [reddit](https://www.reddit.com/r/archlinux/comments/4gc2lw/some_arch_wallpapers_i_made/?st=ivzxvmxu&sh=727d2f4e).
+The original seems to be [this one](https://github.com/dkter/arch-lightdm-theme) according to [this thread](https://www.reddit.com/r/unixporn/comments/rdacpo/comment/ho0k8yt/?utm_source=share&utm_medium=web2x&context=3).
 It's essentially the same thing, but all html/css rather than images. It also uses JetBrains Mono because it is a superior typeface<sup>_fight me_</sup>.
 
 The username/password field is in the bottom right corner, you can't change a WM.


### PR DESCRIPTION
After posting this on [reddit](https://www.reddit.com/r/unixporn/comments/rdacpo/lightdm_made_some_modifications_to_by_favourite/), OP of the greeter linked the [original repo](https://github.com/dkter/arch-lightdm-theme)